### PR TITLE
Self hosted verification

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - RxCocoa (4.0.0):
     - RxSwift (~> 4.0)
-  - RxStoreKit (1.1.0):
+  - RxStoreKit (1.1.1):
     - RxCocoa (~> 4.0.0)
     - RxSwift (~> 4.0.0)
   - RxSwift (4.0.0)
@@ -15,7 +15,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   RxCocoa: d62846ca96495d862fa4c59ea7d87e5031d7340e
-  RxStoreKit: b2edcc0320778f505e2e1dcafd8d7863682d6484
+  RxStoreKit: 04e3364938085492fe79fa9fe98dbf6aedd28611
   RxSwift: fd680d75283beb5e2559486f3c0ff852f0d35334
 
 PODFILE CHECKSUM: e1d5d3ef6890fc1de58f53a3ed76b94c906a9505

--- a/Sources/SKPaymentQueue+Rx.swift
+++ b/Sources/SKPaymentQueue+Rx.swift
@@ -152,19 +152,21 @@ extension Reactive where Base: SKPaymentQueue {
                 })
             let remove = self.transactionObserver.rx_removedTransaction
             
-            let disposable = Observable.of(update, remove)
+            let sharedTransactionResult = Observable.of(update, remove)
                 .merge()
+                .share()
+            let disposable1 = sharedTransactionResult
                 .subscribe(onNext: { transaction in
                     if self.base.transactions.count == 0 {
                         observer.onCompleted()
                     }
                 })
+            let disposable2 = sharedTransactionResult
+                .bind(to: observer)
             
             self.base.add(payment)
             
-            return Disposables.create {
-                disposable.dispose()
-            }
+            return Disposables.create(disposable1, disposable2)
         }
         
         return observable

--- a/Sources/SKPaymentQueue+Rx.swift
+++ b/Sources/SKPaymentQueue+Rx.swift
@@ -133,9 +133,8 @@ extension Reactive where Base: SKPaymentQueue {
         
         let observable = Observable<SKPaymentTransaction>.create { observer in
             
-            let update = self.transactionObserver.rx_updatedTransaction
+            let disposable = self.transactionObserver.rx_updatedTransaction
                 .flatMapLatest({ transaction -> Observable<SKPaymentTransaction> in
-                    print("transaction state = \(transaction.transactionState)")
                     switch transaction.transactionState {
                     case .purchased:
                         if shouldVerify {
@@ -143,22 +142,9 @@ extension Reactive where Base: SKPaymentQueue {
                         } else {
                             return Observable.of(transaction)
                         }
-                    case .failed:
-                        if let transactionError = transaction.error {
-                            return Observable.error(transactionError)
-                        }
-                    default: print(transaction.transactionState)
+                    default: print("transaction state = \(transaction.transactionState)")
                     }
                     return Observable.of(transaction)
-                })
-            
-            let disposable = update
-                .flatMapLatest({ transaction -> Observable<SKPaymentTransaction> in
-                    if self.base.transactions.count == 0 {
-                        return Observable.empty()
-                    } else {
-                        return Observable.of(transaction)
-                    }
                 })
                 .bind(to: observer)
             


### PR DESCRIPTION
* I've added additional parameter to the `add(product:)` function so user can choose how he would verify transactions: by connecting to Apple directly from the device - or by his own logic.
* I had a problems with removed transactions that were fired with the `add(product:)` observable. I was initiating purchase, getting purchased transaction, verified it and then finishing this transaction. But that triggered removed transaction signal and my sequence that were verifying transactions were fired second time. So I removed `rx_removedTransaction` sequence from the `add(product:)` observable.
* Also I retranslate `.failed` and `.deferred` transactions so user can retrieve and finish them.

Tell me if I missed or failed somewhere😀