### PR TITLE
Fix compile error of pod spec lint.

### DIFF
--- a/Sources/SKReceiptRefreshRequestDelegateProxy.swift
+++ b/Sources/SKReceiptRefreshRequestDelegateProxy.swift
@@ -35,12 +35,12 @@ public class SKReceiptRefreshRequestDelegateProxy
     let responseSubject = PublishSubject<SKProductsResponse>()
     
     public func requestDidFinish(_ request: SKRequest) {
-        _forwardToDelegate?.requestDidFinish(request)
+        _forwardToDelegate?.requestDidFinish?(request)
         responseSubject.onCompleted()
     }
     
     public func request(_ request: SKRequest, didFailWithError error: Error) {
-        _forwardToDelegate?.request(request, didFailWithError: error)
+        _forwardToDelegate?.request?(request, didFailWithError: error)
         responseSubject.onError(error)
     }
 


### PR DESCRIPTION
```
-> RxStoreKit (1.2.0)
- ERROR | [iOS] xcodebuild: Returned an unsuccessful exit code. You can use --verbose for more information.
- ERROR | xcodebuild: RxStoreKit/Sources/SKReceiptRefreshRequestDelegateProxy.swift:38:29: error: value of optional type '((SKRequest) -> Void)?' not unwrapped; did you mean to use '!' or '?'?
- ERROR | xcodebuild: RxStoreKit/Sources/SKReceiptRefreshRequestDelegateProxy.swift:43:29: error: value of optional type '((SKRequest, Error) -> Void)?' not unwrapped; did you mean to use '!' or '?'?

Analyzed 1 podspec.
```