### PR TITLE
SKProductRequestにもonErrorを追加する

### DIFF
--- a/Sources/SKProductsRequestDelegateProxy.swift
+++ b/Sources/SKProductsRequestDelegateProxy.swift
@@ -41,7 +41,7 @@ public class SKProductsRequestDelegateProxy
     }
 
     public func request(_ request: SKRequest, didFailWithError error: Error) {
-        _forwardToDelegate?.request(request, didFailWithError: error)
+        _forwardToDelegate?.request?(request, didFailWithError: error)
         responseSubject.onError(error)
     }
 

--- a/Sources/SKProductsRequestDelegateProxy.swift
+++ b/Sources/SKProductsRequestDelegateProxy.swift
@@ -39,7 +39,12 @@ public class SKProductsRequestDelegateProxy
         _forwardToDelegate?.productsRequest(request, didReceive: response)
         responseSubject.onNext(response)
     }
-    
+
+    public func request(_ request: SKRequest, didFailWithError error: Error) {
+        _forwardToDelegate?.request(request, didFailWithError: error)
+        responseSubject.onError(error)
+    }
+
     deinit {
         responseSubject.on(.completed)
     }


### PR DESCRIPTION
SKProductRequestのRequest失敗処理が呼ばれていないのでonErrorを読んであげるようにしました。
