### PR TITLE
Call observer on Completed When TransactionCompleted/ TransactionFailed

### DIFF
--- a/Sources/SKPaymentQueue+Rx.swift
+++ b/Sources/SKPaymentQueue+Rx.swift
@@ -46,7 +46,7 @@ extension ReceiptError: CustomStringConvertible {
 }
 
 extension SKPaymentQueue {
-    func verifyReceipt(transaction: SKPaymentTransaction) -> Observable<SKPaymentTransaction> {
+    func verifyReceipt(transaction: SKPaymentTransaction, excludeOldTransaction: Bool = false) -> Observable<SKPaymentTransaction> {
         #if DEBUG
             let verifyReceiptURLString = "https://sandbox.itunes.apple.com/verifyReceipt"
         #else
@@ -57,7 +57,11 @@ extension SKPaymentQueue {
             let receiptURL = Bundle.main.appStoreReceiptURL
             let data = try Data(contentsOf: receiptURL!, options: [])
             let base64 = data.base64EncodedString(options: Data.Base64EncodingOptions(rawValue: 0))
-            let json = try JSONSerialization.data(withJSONObject: ["receipt-data": base64], options: [])
+            let json = try JSONSerialization.data(withJSONObject:
+                [
+                    "receipt-data": base64,
+                    "exclude-old-transactions": excludeOldTransaction
+                ], options: [])
             
             var request = URLRequest(url: url, cachePolicy: .reloadIgnoringCacheData)
             request.httpMethod = "POST"


### PR DESCRIPTION
Observable<SKPaymentTransaction>が宙ぶらりんになって残ることがあったため、
購入失敗・成功でObservable.onCompletedを呼ぶようにした。
購入失敗系に関しては失敗のErrorが存在するときはonErrorとして流すようにした。
finishTransation処理は必ず呼ばないとqueueから消えないため、内部で呼ぶ処理を追加しました。
レシート認証系はもともと使用していないので変更しておりません。

Obervable remained when payment canceled.
then, the user purchase something, updatedTransaction called multiple times and same transaction emitted.  So dispose  observable<SKPaymentTransaction> when purchase is competed or failed.